### PR TITLE
Change LANGUAGES to all to compile all language files

### DIFF
--- a/mainline-build.zsh
+++ b/mainline-build.zsh
@@ -87,7 +87,7 @@ esac
 
 export CCACHE=1
 export LUA=1
-export LANGUAGES="$(echo $(for i in lang/po/*.po; do echo $(basename $i .po); done))"
+export LANGUAGES="all"
 
 if [[ -z "${DEBUG}" ]]; then
     export RELEASE=1


### PR DESCRIPTION
This should ensure that after https://github.com/CleverRaven/Cataclysm-DDA/pull/38892 is merged, an English `.mo` file is included in the distributions.

Currently the Makefile already supports `LANGUAGES=all` so this should be fine to merge before that PR.