### PR TITLE
Correcetd 'set -x' to 'set -e'

### DIFF
--- a/mainline-build.zsh
+++ b/mainline-build.zsh
@@ -116,9 +116,9 @@ else
     fi
 
     echo "Pulling translations from Transifex"
-    set +x
+    set +e
     tx pull --all --force --minimum-perc 80 --resource cataclysm-dda.master-cataclysm-dda
-    set -x
+    set -e
 
     ## ...package...
     make ${DIST}


### PR DESCRIPTION
I meant to prevent `tx pull` failure from causing the entire build to fail. I mistakenly wrote `set -x`. I actually mean `set -e`.