### PR TITLE
Skip compiling unit tests

### DIFF
--- a/mainline-build.zsh
+++ b/mainline-build.zsh
@@ -91,6 +91,7 @@ esac
 export CCACHE=1
 export LUA=1
 export LANGUAGES="all"
+export RUNTESTS=0
 
 if [[ -z "${DEBUG}" ]]; then
     export RELEASE=1


### PR DESCRIPTION
Take https://ci.narc.ro/job/Cataclysm-Matrix/Graphics=Curses,Platform=Linux_x64/lastBuild/consoleFull as an instance, skip compiling tests save 17 minutes for the Curses Linux x64 target alone.